### PR TITLE
FIX: Abbreviations are not detected depending on punctuation used

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -27,7 +27,7 @@
   let keys = Object.keys(words).sort((x,y) => y.length - x.length);
 
   let escapedWords = "((" + keys.map(w => escapeRegExp(w)).join(")|(") + "))";
-  let regex = new RegExp("\\W" + escapedWords + "\\W", "ig");
+  let regex = new RegExp("(\\W|^)" + escapedWords + "(\\W|$)", "ig");
 
   let createAbbr = function(text) {
       let lower = text.toLowerCase();

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -27,7 +27,7 @@
   let keys = Object.keys(words).sort((x,y) => y.length - x.length);
 
   let escapedWords = "((" + keys.map(w => escapeRegExp(w)).join(")|(") + "))";
-  let regex = new RegExp("(\\s|^)+" + escapedWords + "(([:.;,]+(\\s|$))|\\s|$)", "ig");
+  let regex = new RegExp("\\W" + escapedWords + "\\W", "ig");
 
   let createAbbr = function(text) {
       let lower = text.toLowerCase();


### PR DESCRIPTION
cf. jesus2099/discourse-abbrify-words#1 for examples of non matched abbreviations in MetaBrainz Discourse.

---

Replaced the fixed set of delimiters by a
generic non‐word character (\W) match around the list of abbreviations.

I tested the new regular expression with https://regexr.com

Expression: / `(\W|^)((TLA)|(WIP)|(CAA)|(i\.e\.)|(ストII))(\W|$)` /gi
Text:

> I’m using the MetaBrainz Dark Theme (WIP) as of now! heart_eyes
> Clearly TLA(2) and TLA(3) could get confusing
> With punctuation it does not see the acronyms: CAA? is NG while CAA is OK. :slight_smile:
> use “i.e.” now it 「ストII」 should not only see those WIP, CAA, TLA and i.e., ha ha.

Where now every listed abbreviations are matched instead of only the last ones.
But I cannot test the behaviour inside Discourse itself as a plugin that replaces those matched texts with tooltiped tags.